### PR TITLE
Error while compiling

### DIFF
--- a/H264_capturer/h264framegenerator.cc
+++ b/H264_capturer/h264framegenerator.cc
@@ -66,7 +66,7 @@ void *receive(void *th_arg){
       }
             //AVPacket *packet = av_malloc(sizeof(AVPacket));
             //av_frame_ref (pFrame_ref,decode_th_data->pFrame);
-            Pkt_buf.push(packet);
+            Pkt_buf->push(packet);
       pthread_mutex_unlock(&rcv_th_data->fill_buff_mutex);
 
       pthread_mutex_lock(&rcv_th_data->new_pkt_mutex);


### PR DESCRIPTION
../../webrtc/examples/peerconnection/client/h264framegenerator.cc:69:20: error: member reference type 'std::queue<AVPacket *> *' (aka 'queue<AVPacket *> *') is a pointer; did you mean to use '->'?
            Pkt_buf.push(packet);